### PR TITLE
Fix S3 credentials used to generate url screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,33 @@ Before deploy to AWS, Please make sure the [serverless](https://serverless.com/c
 
 #### Staging
 
-- Create `.env` file setting `S3_BUCKET`
+- Create `.env` file setting `S3_BUCKET`, `CREDENTIALS_ID` & `CREDENTIALS_SECRET`
 
 ```
+# S3 bucket name used to save screenshots
 S3_BUCKET=
+# AWS access key ID
+CREDENTIALS_ID=
+# AWS secret
+CREDENTIALS_SECRET=
 ```
+
+> Note: we can't use env vars `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY` because it's reserved
+> in lambda ecosystem.
 
 ```sls deploy -s staging```
 
 #### Production
 
-- Create `.env` file setting `S3_BUCKET`
+- Create `.env` file setting `S3_BUCKET`, `CREDENTIALS_ID` & `CREDENTIALS_SECRET`
 
 ```
+# S3 bucket name used to save screenshots
 S3_BUCKET=
+# AWS access key ID
+CREDENTIALS_ID=
+# AWS secret
+CREDENTIALS_SECRET=
 ```
 
 ```sls deploy -s production```
@@ -52,7 +65,7 @@ S3_BUCKET=
 
 Install `serverless-offline` plugin, then
 
-```sls offline```
+```sls offline -s staging```
 
 ## Reference
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -53,6 +53,8 @@ functions:
     timeout: 30
     environment:
       S3_BUCKET: ${env:S3_BUCKET}
+      CREDENTIALS_ID: ${env:CREDENTIALS_ID}
+      CREDENTIALS_SECRET: ${env:CREDENTIALS_SECRET}
       HOME: /opt/fonts
     layers:
       - { Ref: FontsLambdaLayer }

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -2,7 +2,10 @@ const S3 = require('aws-sdk/clients/s3');
 const uuid = require('uuid/v4');
 
 function createClient() {
-  return new S3();
+  return new S3({
+    accessKeyId: process.env.CREDENTIALS_ID,
+    secretAccessKey: process.env.CREDENTIALS_SECRET,
+  });
 }
 
 async function uploadBufferImage(client, buffer) {


### PR DESCRIPTION
**Changes:**
As `AWS_ACCESS_KEY_ID` provided by default for each lambda is temporary. So generating a signed URL with it make the link expires when the lambda function is stopped.

In order to fix this, we need to use fixed credentials.

@yobo000 I've tested with the key you gave me and it worked. Could you generate credential for both env? Should I update the staging env-vars with the key you provided?

**JIRA ticket:**
- [Headless Browser] Fix S3 credentials used to generate url screenshot (https://nugitco.atlassian.net/browse/BUGS-3069)